### PR TITLE
Adding black header as per CERN requirements

### DIFF
--- a/src/components/sectionhead.astro
+++ b/src/components/sectionhead.astro
@@ -4,7 +4,7 @@ const { align = "center" } = Astro.props;
 
 <div class:list={["mt-16", align === "center" && "text-center"]}>
   <h1 class="text-4xl lg:text-5xl font-bold lg:tracking-tight">
-    <slot name="title">ASD</slot>
+    <slot name="title">Title</slot>
   </h1>
   <p class="text-lg mt-4 text-slate-600">
     <slot name="desc">Some description goes here</slot>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,9 +9,7 @@ import Layout from "@layouts/Layout.astro";
 ---
 
 <Layout title="">
-  
   <Container>
-
     <Hero />
     <Features />
     <Logos />


### PR DESCRIPTION
Added black CERN header roughly following the CERN design [guidelines](https://design-guidelines.web.cern.ch/guidelines/guidelines-cern-websites).